### PR TITLE
Update Readme.MD for sobj

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ short unknown                       (2 bytes)                            # unkno
 object[object_count]                (obj_count * obj_size bytes)         # list of object structures
 
 typedef struct {
+  int unknown                       (4 bytes)                            # unknown byte (typically 0xFFFFFFFF)
+  byte unknown                      (1 byte)                             # unknown byte (typically 0x00)
   byte movement_directions          (1 byte)                             # movement directions for static object (see list below)
   byte tile_count                   (1 byte)                             # number of tiles in static object
   short[tile_count]                 (tile_count * 2 bytes)               # list of tile indicies for static object


### PR DESCRIPTION
there are 5 unknown bytes in each sobj that isn't referenced in the readme.  See the link below for the lines of code where we skip over those 5 bytes

https://github.com/DizzyThermal/TKViewer/blob/96e1b0edbe4d64b74c16b6ab9c2e094552fd3dbb/src/main/java/com/gamemode/tkviewer/file_handlers/SObjTblFileHandler.java#L37