### PR TITLE
fix(renderer): export all effect frames

### DIFF
--- a/common/src/main/java/com/gamemode/tkviewer/render/EffectRenderer.java
+++ b/common/src/main/java/com/gamemode/tkviewer/render/EffectRenderer.java
@@ -182,7 +182,7 @@ public class EffectRenderer implements Renderer {
 
     @Override
     public int getFrameIndex(int index, int offset) {
-        return index;
+        return index + offset;
     }
 
     @Override


### PR DESCRIPTION
Fixes a small logic issue where only one frame from each effect would be exported.