### PR TITLE
Animation sheet exporter

### DIFF
--- a/common/src/main/java/com/gamemode/tkviewer/TKDumper.java
+++ b/common/src/main/java/com/gamemode/tkviewer/TKDumper.java
@@ -103,7 +103,7 @@ public class TKDumper {
         }
 
         for (int i = 0; i < renderer.getCount(); i++) {
-            Image[] images = renderer.getFrames(i);
+            Image[] images = renderer.getFrames(i, -1);
             String epfName = renderer.getEpfNameForFrame(i);
             for (int j = 0; j < images.length; j++) {
                 try {

--- a/common/src/main/java/com/gamemode/tkviewer/gui/ViewFrame.java
+++ b/common/src/main/java/com/gamemode/tkviewer/gui/ViewFrame.java
@@ -35,7 +35,8 @@ public class ViewFrame extends JFrame implements ActionListener {
 
     Image clientIcon;
     JPanel imagePanel;
-    JList list;
+    JList itemList;
+    JList paletteList;
     Integer itemCount;
 
     JButton exportFramesButton;
@@ -106,30 +107,44 @@ public class ViewFrame extends JFrame implements ActionListener {
         for (int i = 0; i < itemCount; i++) {
             items[i] = this.singular + " " + i;
         }
-        list = new JList(items);
-        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        list.setLayoutOrientation(JList.VERTICAL);
-        list.setVisibleRowCount(-1);
-        list.addListSelectionListener(new ListSelectionListener() {
+        itemList = new JList(items);
+        itemList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        itemList.setLayoutOrientation(JList.VERTICAL);
+        itemList.setVisibleRowCount(-1);
+        itemList.addListSelectionListener(new ListSelectionListener() {
             @Override
             public void valueChanged(ListSelectionEvent e) {
                 if (!e.getValueIsAdjusting()) {
-                    int idx = list.getSelectedIndex();
-                    if (renderers.get(0) instanceof MobRenderer && !framesButton.isSelected()) {
-                        renderMobAnimations(idx);
-                    } else if (renderers.get(0) instanceof EffectRenderer && !framesButton.isSelected()) {
-                        renderEffectAnimations(idx);
-                    } else if (renderers.get(0) instanceof PartRenderer && !framesButton.isSelected()) {
-                        renderPartAnimations(idx);
-                    } else {
-                        renderFrames(idx);
-                    }
+                    renderItem(itemList.getSelectedIndex());
                 }
             }
         });
 
-        JScrollPane scroller = new JScrollPane(list);
+        JScrollPane scroller = new JScrollPane(itemList);
         scroller.setPreferredSize(new Dimension(150, 520));
+
+        long paletteCount = renderers.get(0).getPaletteCount();
+        String[] palettes = new String[(int)paletteCount + 1];
+        palettes[0] = "Default Palette";
+        for (int i = 0; i < paletteCount; i++) {
+            palettes[i + 1] = "Palette " + i;
+        }
+
+        paletteList = new JList(palettes);
+        paletteList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        paletteList.setLayoutOrientation(JList.VERTICAL);
+        paletteList.setVisibleRowCount(-1);
+        paletteList.addListSelectionListener(new ListSelectionListener() {
+            @Override
+            public void valueChanged(ListSelectionEvent e) {
+                if (!e.getValueIsAdjusting()) {
+                    renderItem(itemList.getSelectedIndex());
+                }
+            }
+        });
+
+        JScrollPane paletteScroller = new JScrollPane(paletteList);
+        paletteScroller.setPreferredSize(new Dimension(150, 520));
 
         JPanel statusPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         statusPanel.setBorder(new LineBorder(Color.BLACK));
@@ -161,6 +176,9 @@ public class ViewFrame extends JFrame implements ActionListener {
         statusPanel.add(animationsButton);
 
         this.add(scroller, BorderLayout.WEST);
+        if (paletteCount > 1) {
+            this.add(paletteScroller, BorderLayout.EAST);
+        }
         this.add(imagePanel, BorderLayout.CENTER);
         this.add(statusPanel, BorderLayout.SOUTH);
 
@@ -189,6 +207,15 @@ public class ViewFrame extends JFrame implements ActionListener {
         imagePanel.removeAll();
         imagePanel.revalidate();
         imagePanel.repaint();
+    }
+
+    private int getPaletteIndex() {
+        int selectedIndex = paletteList.getSelectedIndex();
+        if (selectedIndex >= 0) {
+            return selectedIndex - 1;
+        } else {
+            return -1;
+        }
     }
 
     public int determineEpfIndex(int index) {
@@ -221,6 +248,24 @@ public class ViewFrame extends JFrame implements ActionListener {
         return currentRendererIndex;
     }
 
+    private void renderItem(int itemIndex) {
+        if (itemIndex == -1) {
+            // Don't render anything until a list selection is made
+            return;
+        }
+        if (framesButton.isSelected()) {
+            renderFrames(itemIndex);
+        } else if (renderers.get(0) instanceof MobRenderer) {
+            renderMobAnimations(itemIndex);
+        } else if (renderers.get(0) instanceof EffectRenderer) {
+            renderEffectAnimations(itemIndex);
+        } else if (renderers.get(0) instanceof PartRenderer) {
+            renderPartAnimations(itemIndex);
+        } else {
+            renderFrames(itemIndex);
+        }
+    }
+
     public void renderEffectAnimations(int index) {
         this.renderEffectAnimations(determineEpfIndex(index), determineRendererIndex(index));
     }
@@ -229,13 +274,14 @@ public class ViewFrame extends JFrame implements ActionListener {
         clearImagePanel();
 
         // Get Effect Images
-        List<EffectImage> images = ((EffectRenderer) renderers.get(rendererIndex)).renderEffect(index);
+        int paletteIndex = getPaletteIndex();
+        List<EffectImage> images = ((EffectRenderer) renderers.get(rendererIndex)).renderAnimation(index, paletteIndex);
 
         // Create GIF in Temp Directory
         if (!new File(Resources.EFFECT_ANIMATION_DIRECTORY).exists()) {
             new File(Resources.EFFECT_ANIMATION_DIRECTORY).mkdirs();
         }
-        String gifPath = (Resources.EFFECT_ANIMATION_DIRECTORY + File.separator + "effect-" + index + "-" + rendererIndex + ".gif");
+        String gifPath = (Resources.EFFECT_ANIMATION_DIRECTORY + File.separator + "effect-" + index + "-" + rendererIndex + "-" + paletteIndex + ".gif");
         if (!new File(gifPath).exists()) {
             FileUtils.exportGifFromImages(images, gifPath);
         }
@@ -266,13 +312,13 @@ public class ViewFrame extends JFrame implements ActionListener {
         }
 
         MobRenderer mobRenderer = ((MobRenderer) renderers.get(rendererIndex));
-
+        int paletteIndex = getPaletteIndex();
         List<String> gifPaths = new ArrayList<String>();
         Mob mob = mobRenderer.mobDna.mobs.get(index);
         for (int i = 0; i < mob.getChunks().size(); i++) {
-            List<EffectImage> chunkImages = mobRenderer.renderAnimation(index, i);
+            List<EffectImage> chunkImages = mobRenderer.renderAnimation(index, i, paletteIndex);
             if (chunkImages.size() != 0) {
-                String gifPath = outputDirectory + File.separator + singular + "-" + index + "-" + i + "-" + rendererIndex + ".gif";
+                String gifPath = outputDirectory + File.separator + singular + "-" + index + "-" + i + "-" + rendererIndex + "-" + paletteIndex + ".gif";
                 FileUtils.exportGifFromImages(chunkImages, gifPath);
                 gifPaths.add(gifPath);
             }
@@ -310,11 +356,12 @@ public class ViewFrame extends JFrame implements ActionListener {
         PartRenderer partRenderer = ((PartRenderer) renderers.get(rendererIndex));
 
         List<String> gifPaths = new ArrayList<String>();
+        int paletteIndex = getPaletteIndex();
         Part part = partRenderer.partDsc.parts.get(index);
         for (int i = 0; i < part.getChunks().size(); i++) {
-            List<EffectImage> chunkImages = partRenderer.renderAnimation(index, i);
+            List<EffectImage> chunkImages = partRenderer.renderAnimation(index, i, paletteIndex);
             if (chunkImages.size() != 0) {
-                String gifPath = outputDirectory + File.separator + singular + "-" + index + "-" + i + "-" + rendererIndex + ".gif";
+                String gifPath = outputDirectory + File.separator + singular + "-" + index + "-" + i + "-" + rendererIndex + "-" + paletteIndex + ".gif";
                 FileUtils.exportGifFromImages(chunkImages, gifPath);
                 gifPaths.add(gifPath);
             }
@@ -343,7 +390,7 @@ public class ViewFrame extends JFrame implements ActionListener {
     public void renderFrames(int index, int rendererIndex) {
         clearImagePanel();
 
-        Image[] images = renderers.get(rendererIndex).getFrames(index);
+        Image[] images = renderers.get(rendererIndex).getFrames(index, getPaletteIndex());
         for (int i = 0; i < images.length; i++) {
             final int frameIndex = renderers.get(rendererIndex).getFrameIndex(index, i);
             JLabel jLabel = new JLabel(new ImageIcon(images[i]));
@@ -385,10 +432,11 @@ public class ViewFrame extends JFrame implements ActionListener {
         fileChooser.setDialogTitle("Choose export directory");
         int result = fileChooser.showSaveDialog(this);
         if (result == JFileChooser.APPROVE_OPTION) {
-            Image[] images = renderers.get(rendererIndex).getFrames(index);
+            int paletteIndex = getPaletteIndex();
+            Image[] images = renderers.get(rendererIndex).getFrames(index, paletteIndex);
             for (int i = 0; i < images.length; i++) {
                 final int frameIndex = renderers.get(rendererIndex).getFrameIndex(index, i);
-                FileUtils.writeBufferedImageToFile(((BufferedImage) images[i]), Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + "-" + frameIndex + ".png").toString());
+                FileUtils.writeBufferedImageToFile(((BufferedImage) images[i]), Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + "-" + frameIndex + "-" + paletteIndex + ".png").toString());
             }
 
             JOptionPane.showMessageDialog(this, "Frames exported successfully!", "TKViewer", JOptionPane.INFORMATION_MESSAGE);
@@ -408,13 +456,14 @@ public class ViewFrame extends JFrame implements ActionListener {
             EffectRenderer effectRenderer = (EffectRenderer) renderers.get(rendererIndex);
             List<List<BufferedImage>> imageGrid = new ArrayList<>();
             List<BufferedImage> images = new ArrayList<BufferedImage>();
-            List<EffectImage> effectImages = effectRenderer.renderEffect(index);
+            int paletteIndex = getPaletteIndex();
+            List<EffectImage> effectImages = effectRenderer.renderAnimation(index, paletteIndex);
             for (int j = 0; j < effectImages.size(); j++) {
                 images.add((BufferedImage)effectImages.get(j).getImage());
             }
             imageGrid.add(images);
 
-            FileUtils.writeImageGridToFile(imageGrid, Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + ".png").toString());
+            FileUtils.writeImageGridToFile(imageGrid, Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + "-" + paletteIndex + ".png").toString());
 
             JOptionPane.showMessageDialog(this, "Animation Sheet exported successfully!", "TKViewer", JOptionPane.INFORMATION_MESSAGE);
         }
@@ -433,15 +482,16 @@ public class ViewFrame extends JFrame implements ActionListener {
             MobRenderer mobRenderer = (MobRenderer) renderers.get(rendererIndex);
             List<List<BufferedImage>> imageGrid = new ArrayList<>();
             Mob mob = mobRenderer.mobDna.mobs.get(index);
+            int paletteIndex = getPaletteIndex();
             for (int i = 0; i < mob.getChunks().size(); i++) {
                 List<BufferedImage> images = new ArrayList<BufferedImage>();
-                List<EffectImage> chunkImages = mobRenderer.renderAnimation(index, i);
+                List<EffectImage> chunkImages = mobRenderer.renderAnimation(index, i, paletteIndex);
                 for (int j = 0; j < chunkImages.size(); j++) {
                     images.add((BufferedImage)chunkImages.get(j).getImage());
                 }
                 imageGrid.add(images);
             }
-            FileUtils.writeImageGridToFile(imageGrid, Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + ".png").toString());
+            FileUtils.writeImageGridToFile(imageGrid, Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + "-" + paletteIndex + ".png").toString());
 
             JOptionPane.showMessageDialog(this, "Animation Sheet exported successfully!", "TKViewer", JOptionPane.INFORMATION_MESSAGE);
         }
@@ -460,15 +510,16 @@ public class ViewFrame extends JFrame implements ActionListener {
             PartRenderer partRenderer = ((PartRenderer) renderers.get(rendererIndex));
             List<List<BufferedImage>> imageGrid = new ArrayList<>();
             Part part = partRenderer.partDsc.parts.get(index);
+            int paletteIndex = getPaletteIndex();
             for (int i = 0; i < part.getChunks().size(); i++) {
                 List<BufferedImage> images = new ArrayList<BufferedImage>();
-                List<EffectImage> chunkImages = partRenderer.renderAnimation(index, i);
+                List<EffectImage> chunkImages = partRenderer.renderAnimation(index, i, paletteIndex);
                 for (int j = 0; j < chunkImages.size(); j++) {
                     images.add((BufferedImage)chunkImages.get(j).getImage());
                 }
                 imageGrid.add(images);
             }
-            FileUtils.writeImageGridToFile(imageGrid, Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + ".png").toString());
+            FileUtils.writeImageGridToFile(imageGrid, Paths.get(fileChooser.getSelectedFile().toString(), singular + "-" + index + "-" + paletteIndex + ".png").toString());
 
             JOptionPane.showMessageDialog(this, "Animation Sheet exported successfully!", "TKViewer", JOptionPane.INFORMATION_MESSAGE);
         }
@@ -477,34 +528,33 @@ public class ViewFrame extends JFrame implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent ae) {
-        int listIndex = list.getSelectedIndex();
+        int itemIndex = itemList.getSelectedIndex();
 
-        if (listIndex == -1) {
+        if (itemIndex == -1) {
             // Don't render anything until a list selection is made
             return;
         }
 
         if (ae.getSource() == this.framesButton) {
-            this.renderFrames(listIndex);
+            this.renderFrames(itemIndex);
         } else if (ae.getSource() == this.animationsButton) {
             if (renderers.get(0) instanceof EffectRenderer) {
-                this.renderEffectAnimations(listIndex);
+                this.renderEffectAnimations(itemIndex);
             } else if (renderers.get(0) instanceof PartRenderer) {
-                this.renderPartAnimations(listIndex);
+                this.renderPartAnimations(itemIndex);
             } else if (renderers.get(0) instanceof MobRenderer) {
-                this.renderMobAnimations(listIndex);
+                this.renderMobAnimations(itemIndex);
             }
         } else if (ae.getSource() == this.exportFramesButton) {
-            this.exportFrames(listIndex);
+            this.exportFrames(itemIndex);
         } else if (ae.getSource() == this.exportAnimationSheetButton) {
             if (renderers.get(0) instanceof EffectRenderer) {
-                this.exportEffectAnimationSheet(listIndex);
+                this.exportEffectAnimationSheet(itemIndex);
             } else if (renderers.get(0) instanceof PartRenderer) {
-                this.exportPartAnimationSheet(listIndex);
+                this.exportPartAnimationSheet(itemIndex);
             } else if (renderers.get(0) instanceof MobRenderer) {
-                this.exportMobAnimationSheet(listIndex);
+                this.exportMobAnimationSheet(itemIndex);
             }
-
         }
     }
 }

--- a/common/src/main/java/com/gamemode/tkviewer/render/EffectRenderer.java
+++ b/common/src/main/java/com/gamemode/tkviewer/render/EffectRenderer.java
@@ -45,7 +45,7 @@ public class EffectRenderer implements Renderer {
         this.tileRenderer = new TileRenderer(effectEpfs, effectPal, effectFrm);
     }
 
-    public List<EffectImage> renderEffect(int effectIndex) {
+    public List<EffectImage> renderAnimation(int effectIndex, int paletteIndex) {
         // Determine Frame Range for Effect
         List<EffectFrame> effectFrames = this.effectEfxTbl.effects.get(effectIndex).getEffectFrames();
         int effectFrameCount = effectFrames.size();
@@ -83,7 +83,10 @@ public class EffectRenderer implements Renderer {
             Graphics2D graphicsObject = frameImage.createGraphics();
             EffectFrame effectFrame = effectFrames.get(i);
 
-            BufferedImage tile = this.renderEffectImage(effectFrame.getFrameIndex(), this.effectFrm.paletteIndices.get(effectFrame.getFrameIndex()));
+            BufferedImage tile = this.renderEffect(
+                effectFrame.getFrameIndex(),
+                paletteIndex >= 0 ? paletteIndex : this.effectFrm.paletteIndices.get(effectFrame.getFrameIndex())
+            );
             Frame frame = FileUtils.getFrameFromEpfs(effectFrame.getFrameIndex(), effectEpfs);
             if (frame == null) {
                 continue;
@@ -101,7 +104,7 @@ public class EffectRenderer implements Renderer {
         return images;
     }
 
-    public BufferedImage renderEffectImage(int tileIndex, int paletteIndex) {
+    public BufferedImage renderEffect(int tileIndex, int paletteIndex) {
         int epfIndex = 0;
 
         int frameCount = 0;
@@ -170,8 +173,13 @@ public class EffectRenderer implements Renderer {
     }
 
     @Override
-    public Image[] getFrames(int index) {
-        List<EffectImage> effects = this.renderEffect(index);
+    public long getPaletteCount() {
+        return this.effectPal.paletteCount;
+    }
+
+    @Override
+    public Image[] getFrames(int index, int paletteIndex) {
+        List<EffectImage> effects = this.renderAnimation(index, paletteIndex);
         Image[] frames = new Image[effects.size()];
         for (int i = 0; i < frames.length; i++) {
             frames[i] = effects.get(i).getImage();

--- a/common/src/main/java/com/gamemode/tkviewer/render/MobRenderer.java
+++ b/common/src/main/java/com/gamemode/tkviewer/render/MobRenderer.java
@@ -167,11 +167,11 @@ public class MobRenderer implements Renderer {
         return new int[]{l, t, r, b};
     }
 
-    public List<EffectImage> renderAnimation(int mobIndex, ANIMATIONS animation) {
-        return renderAnimation(mobIndex, animation.ordinal());
+    public List<EffectImage> renderAnimation(int mobIndex, ANIMATIONS animation, int paletteIndex) {
+        return renderAnimation(mobIndex, animation.ordinal(), paletteIndex);
     }
 
-    public List<EffectImage> renderAnimation(int mobIndex, int chunkIndex) {
+    public List<EffectImage> renderAnimation(int mobIndex, int chunkIndex, int paletteIndex) {
         Mob mob = this.mobDna.mobs.get(mobIndex);
         MobChunk chunk = mob.getChunks().get(chunkIndex);
 
@@ -193,7 +193,7 @@ public class MobRenderer implements Renderer {
             MobBlock block = chunk.getBlocks().get(i);
             int frameIndex = (int)(mob.getFrameIndex() + block.getFrameOffset());
 
-            BufferedImage tile = this.renderMob(frameIndex, mob.getPaletteId());
+            BufferedImage tile = this.renderMob(frameIndex, paletteIndex >= 0 ? paletteIndex : mob.getPaletteId());
             Frame frame = FileUtils.getFrameFromEpfs(frameIndex, mobEpfs);
             if (frame == null) {
                 continue;
@@ -234,7 +234,12 @@ public class MobRenderer implements Renderer {
     }
 
     @Override
-    public Image[] getFrames(int index) {
+    public long getPaletteCount() {
+        return this.mobPal.paletteCount;
+    }
+
+    @Override
+    public Image[] getFrames(int index, int paletteIndex) {
         Mob mob = this.mobDna.mobs.get(index);
         int frameIndex = (int)mob.getFrameIndex();
         int maxFrameOffset = 0;
@@ -249,7 +254,7 @@ public class MobRenderer implements Renderer {
         int imageCount = maxFrameOffset + 1;
         Image[] frames = new Image[imageCount];
         for (int i = 0; i < imageCount; i++) {
-            frames[i] = this.renderMob(frameIndex + i, mob.getPaletteId());
+            frames[i] = this.renderMob(frameIndex + i, paletteIndex >= 0 ? paletteIndex : mob.getPaletteId());
         }
 
         return frames;

--- a/common/src/main/java/com/gamemode/tkviewer/render/MobRenderer.java
+++ b/common/src/main/java/com/gamemode/tkviewer/render/MobRenderer.java
@@ -199,12 +199,13 @@ public class MobRenderer implements Renderer {
                 continue;
             }
 
+            float alpha = 1.0f - ((float) block.getTransparency() / 255.0f);
+            graphicsObject.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
             graphicsObject.drawImage(
                     tile,
                     null,
                     (frame.getLeft() - l),
                     (frame.getTop() - t));
-            graphicsObject.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float)block.getTransparency()/(float)255));
 
             images.add(new EffectImage(frameImage, block.getDuration(), null, null));
         }

--- a/common/src/main/java/com/gamemode/tkviewer/render/PartRenderer.java
+++ b/common/src/main/java/com/gamemode/tkviewer/render/PartRenderer.java
@@ -106,7 +106,7 @@ public class PartRenderer implements Renderer {
         SWING_LEFT_1H_2             // 66
     }
 
-    Map<Integer, BufferedImage> parts;
+    Map<String, BufferedImage> parts;
 
     public List<EpfFileHandler> partEpfs;
     public PalFileHandler partPal;
@@ -122,7 +122,7 @@ public class PartRenderer implements Renderer {
     }
 
     public PartRenderer(String partName, DatFileHandler charDat, boolean isBaram) {
-        parts = new HashMap<Integer, BufferedImage>();
+        parts = new HashMap<String, BufferedImage>();
 
         this.partEpfs = FileUtils.createEpfsFromDats(partName, isBaram);
         this.partPal = new PalFileHandler(charDat.getFile(partName + ".pal"));
@@ -130,7 +130,7 @@ public class PartRenderer implements Renderer {
     }
 
     public PartRenderer(List<EpfFileHandler> partEpfs, PalFileHandler partPal, DscFileHandler partDsc) {
-        parts = new HashMap<Integer, BufferedImage>();
+        parts = new HashMap<String, BufferedImage>();
 
         this.partEpfs = partEpfs;
         this.partPal = partPal;
@@ -138,7 +138,7 @@ public class PartRenderer implements Renderer {
     }
 
     public PartRenderer(String tkDataDirectory, PART_RENDERER_TYPE rendererType) {
-        parts = new HashMap<Integer, BufferedImage>();
+        parts = new HashMap<String, BufferedImage>();
 
         String epfPrefix = null;
         String palName = null;
@@ -225,7 +225,7 @@ public class PartRenderer implements Renderer {
     }
 
     public PartRenderer(List<EpfFileHandler> partEpfs, PalFileHandler partPal, int manualPaletteIndex) {
-        parts = new HashMap<Integer, BufferedImage>();
+        parts = new HashMap<String, BufferedImage>();
 
         this.partEpfs = partEpfs;
         this.partPal = partPal;
@@ -269,8 +269,9 @@ public class PartRenderer implements Renderer {
 
     public BufferedImage renderPart(int partIndex, int frameIndex, int frameOffset, int paletteIndex) {
         // Return Part if cached.
-        if (parts.containsKey(frameIndex + frameOffset)) {
-            return parts.get(frameIndex + frameOffset);
+        String cacheKey = frameIndex + frameOffset + "-" + paletteIndex;
+        if (parts.containsKey(cacheKey)) {
+            return parts.get(cacheKey);
         }
 
         Frame frame = getFrame(frameIndex, frameOffset);
@@ -312,7 +313,7 @@ public class PartRenderer implements Renderer {
             }
         }
 
-        this.parts.put(frameIndex + frameOffset, image);
+        this.parts.put(cacheKey, image);
         return image;
     }
 
@@ -431,13 +432,18 @@ public class PartRenderer implements Renderer {
     }
 
     @Override
-    public Image[] getFrames(int index) {
+    public long getPaletteCount() {
+        return this.partPal.paletteCount;
+    }
+
+    @Override
+    public Image[] getFrames(int index, int paletteIndex) {
         Image[] frames = new Image[(int) this.partDsc.parts.get(index).getFrameCount()];
         for (int i = 0; i < this.partDsc.parts.get(index).getFrameCount(); i++) {
             frames[i] = this.renderPart(index,
                     (int) this.partDsc.parts.get(index).getFrameIndex(),
                     i,
-                    (int) this.partDsc.parts.get(index).getPaletteId());
+                    paletteIndex >= 0 ? paletteIndex : (int) this.partDsc.parts.get(index).getPaletteId());
         }
 
         return frames;

--- a/common/src/main/java/com/gamemode/tkviewer/render/Renderer.java
+++ b/common/src/main/java/com/gamemode/tkviewer/render/Renderer.java
@@ -5,8 +5,9 @@ import java.awt.*;
 public interface Renderer {
     int getCount();
     int getCount(boolean useEpfCount);
-    Image[] getFrames(int index);
+    Image[] getFrames(int index, int paletteIndex);
     String getInfo(int index);
     int getFrameIndex(int index, int offset);
     void dispose();
+    long getPaletteCount();
 }

--- a/common/src/main/java/com/gamemode/tkviewer/utilities/FileUtils.java
+++ b/common/src/main/java/com/gamemode/tkviewer/utilities/FileUtils.java
@@ -13,6 +13,9 @@ import com.gamemode.tkviewer.third_party.GifSequenceWriter;
 
 import javax.imageio.*;
 import javax.imageio.stream.*;
+
+import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.image.*;
 import java.io.FileWriter;
 import java.io.*;
@@ -219,6 +222,44 @@ public class FileUtils {
     public static void writeBufferedImageToFile(BufferedImage image, String outputPath) {
         try {
             ImageIO.write(image, "png", new File(outputPath));
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    public static void writeImageGridToFile(List<List<BufferedImage>> imageGrid, String outputPath) {
+        try {
+            int sheetWidth = 0;
+            int sheetHeight = 0;
+
+            for (int i = 0; i < imageGrid.size(); i++) {
+                List<BufferedImage> imageList = imageGrid.get(i);
+                Image first = (Image)imageList.get(0);
+                int width = first.getWidth(null);
+                int height = first.getHeight(null);
+                sheetWidth = Math.max(sheetWidth, imageList.size() * width);
+                sheetHeight += height;
+            }
+
+            BufferedImage sheet = new BufferedImage(sheetWidth, sheetHeight, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2d = sheet.createGraphics();
+
+            int y = 0;
+            for (int i = 0; i < imageGrid.size(); i++) {
+                List<BufferedImage> imageList = imageGrid.get(i);
+                Image first = (Image)imageList.get(0);
+
+                // All images within one chunk are to be same size
+                int width = first.getWidth(null);
+                int height = first.getHeight(null);
+                for (int j = 0; j < imageList.size(); j++) {
+                    g2d.drawImage(imageList.get(j), width * j, y, null);
+                }
+                y += height;
+            }
+            g2d.dispose();
+
+            ImageIO.write(sheet, "png", new File(outputPath));
         } catch (IOException ioe) {
             ioe.printStackTrace();
         }


### PR DESCRIPTION
These changes might be too bespoke to my needs so feel free to discard this PR or I can isolate the parts you think would be good to bring upstream. I made good efforts to maintain existing functionality while adding new capabilities, but I may have overlooked some nuance. This one image summarizes basically all of the changes.

<img width="1764" height="1411" alt="Mob-28" src="https://github.com/user-attachments/assets/913e1b57-339a-44b4-8cb7-68759f11e595" />

1. Fixed an issue with alpha not being respected when dumping frame images (see death animation fade out)
2. Allow dumping all images for an item into one animation sheet, with each row being one `chunk` (see the whole layout)
3. Added a palette picker to the ViewFrame (see the purpleness from some random palette)
4. Not seen in the image, but if you toggle between Frames and Animations while viewing Mobs, animations would not reappear. That's fixed too.